### PR TITLE
Fix invalid shadow_very_high presets

### DIFF
--- a/Lighting/DiskLight/disk_lighting.fxsub
+++ b/Lighting/DiskLight/disk_lighting.fxsub
@@ -58,7 +58,7 @@ static const float3 viewLightUp = cross(viewLightDirection, viewLightRight);
 #   define SHADOW_MAP_SIZE 256
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_SIZE 512
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_SIZE 1024
 #elif SHADOW_MAP_QUALITY >= 3
 #   define SHADOW_MAP_SIZE 2048

--- a/Lighting/PointLight/point_lighting.fxsub
+++ b/Lighting/PointLight/point_lighting.fxsub
@@ -46,7 +46,7 @@ static const float3 viewLightPosition = mul(float4(LightPosition, 1), matView).x
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_WIDTH 512
 #   define SHADOW_MAP_HEIGHT 1024
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_WIDTH 1024
 #   define SHADOW_MAP_HEIGHT 2048
 #elif SHADOW_MAP_QUALITY >= 3

--- a/Lighting/PointLightIES/IES_lighting.fxsub
+++ b/Lighting/PointLightIES/IES_lighting.fxsub
@@ -49,7 +49,7 @@ static const float3 viewLightDirection = normalize(mul(LightDirection, (float3x3
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_WIDTH 512
 #   define SHADOW_MAP_HEIGHT 1024
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_WIDTH 1024
 #   define SHADOW_MAP_HEIGHT 2048
 #elif SHADOW_MAP_QUALITY >= 3

--- a/Lighting/RectangleLight/rectangle_lighting.fxsub
+++ b/Lighting/RectangleLight/rectangle_lighting.fxsub
@@ -64,7 +64,7 @@ static const float3 viewLightUp = normalize(cross(viewLightDirection, viewLightR
 #   define SHADOW_MAP_SIZE 256
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_SIZE 512
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_SIZE 1024
 #elif SHADOW_MAP_QUALITY >= 3
 #   define SHADOW_MAP_SIZE 2048

--- a/Lighting/SphereLight/sphere_lighting.fxsub
+++ b/Lighting/SphereLight/sphere_lighting.fxsub
@@ -79,7 +79,7 @@ float3 DecodeHDR(float4 rgbx)
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_WIDTH 512
 #   define SHADOW_MAP_HEIGHT 1024
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_WIDTH 1024
 #   define SHADOW_MAP_HEIGHT 2048
 #elif SHADOW_MAP_QUALITY >= 3

--- a/Lighting/SpotLight/spot_lighting.fxsub
+++ b/Lighting/SpotLight/spot_lighting.fxsub
@@ -50,7 +50,7 @@ static const float3 viewLightDirection = normalize(mul(-LightDirection, (float3x
 #   define SHADOW_MAP_SIZE 256
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_SIZE 512
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_SIZE 1024
 #elif SHADOW_MAP_QUALITY >= 3
 #   define SHADOW_MAP_SIZE 2048

--- a/Lighting/SpotLightIES/IES_lighting.fxsub
+++ b/Lighting/SpotLightIES/IES_lighting.fxsub
@@ -50,7 +50,7 @@ static const float3 viewLightDirection = normalize(mul(-LightDirection, (float3x
 #   define SHADOW_MAP_SIZE 256
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_SIZE 512
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_SIZE 1024
 #elif SHADOW_MAP_QUALITY >= 3
 #   define SHADOW_MAP_SIZE 2048

--- a/Lighting/TubeLight/Default Ambient/tube_lighting_with_shadow_very_high.fx
+++ b/Lighting/TubeLight/Default Ambient/tube_lighting_with_shadow_very_high.fx
@@ -1,11 +1,11 @@
-#define LIGHT_PARAMS_TYPE 0
+#define LIGHT_PARAMS_TYPE 1
 
 static const float3 lightRangeParams = float3(100.0, 0.0, 200.0);
 static const float3 lightIntensityParams = float3(100, 0.0, 2000.0);
 static const float3 lightAttenuationBulbParams = float3(1.0, 0.0, 5.0);
 
 #define SHADOW_MAP_FROM 1
-#define SHADOW_MAP_QUALITY 2
+#define SHADOW_MAP_QUALITY 3
 
 static const float2 shadowHardness = float2(0.2, 0.995);
 

--- a/Lighting/TubeLight/Default/tube_lighting_with_shadow_very_high.fx
+++ b/Lighting/TubeLight/Default/tube_lighting_with_shadow_very_high.fx
@@ -1,11 +1,11 @@
-#define LIGHT_PARAMS_TYPE 1
+#define LIGHT_PARAMS_TYPE 0
 
 static const float3 lightRangeParams = float3(100.0, 0.0, 200.0);
 static const float3 lightIntensityParams = float3(100, 0.0, 2000.0);
 static const float3 lightAttenuationBulbParams = float3(1.0, 0.0, 5.0);
 
 #define SHADOW_MAP_FROM 1
-#define SHADOW_MAP_QUALITY 2
+#define SHADOW_MAP_QUALITY 3
 
 static const float2 shadowHardness = float2(0.2, 0.995);
 

--- a/Lighting/TubeLight/tube_lighting.fxsub
+++ b/Lighting/TubeLight/tube_lighting.fxsub
@@ -59,7 +59,7 @@ static const float3 viewLightRight = mul(float4(LightRight, 1), matView).xyz;
 #elif SHADOW_MAP_QUALITY == 1
 #   define SHADOW_MAP_WIDTH 512
 #   define SHADOW_MAP_HEIGHT 1024
-#elif SHADOW_MAP_QUALITY >= 2
+#elif SHADOW_MAP_QUALITY == 2
 #   define SHADOW_MAP_WIDTH 1024
 #   define SHADOW_MAP_HEIGHT 2048
 #elif SHADOW_MAP_QUALITY >= 3


### PR DESCRIPTION
This PR fixes a typo in conditions checking the value of `SHADOW_MAP_QUALITY`, which causes `shadow_very_high.fx` to have the same effect as `shadow_high.fx`.

Also fixes an issue where tube light's `very_high.fx` has the same `SHADOW_MAP_QUALITY` value as `high.fx`, as well as renaming those files.

Before:
(using `spot_lighting_with_shadow_very_high.fx`, but got the same effect as `spot_lighting_with_shadow_high.fx`)
![screenshot shadow](https://user-images.githubusercontent.com/46285865/140986520-f42e9983-91eb-41e2-b044-af371df96d1f.png)

After:
![screenshot shadow1](https://user-images.githubusercontent.com/46285865/140986587-1582e3bf-2e47-4a91-b900-cd9c8413e3c9.png)

Besides, I noticed another inconsistency regarding fog shadows, where quality variable is named `VOLUMETRIC_FOG_MAP_QUALITY` in shadow presets (such as `spot_fog_with_shadow_high.fx`), but named `VOLUMETRIC_FOG_QUALITY` in files that reference it (such as `spot_fog.fxsub`). I wasn't sure if this is expected, so just left them untouched.

Btw, looks like this project has got some development activities recently, I'm glad to see that!