### PR TITLE
Fix incorrect normals of two-sided materials; optional define to disable

### DIFF
--- a/Materials/material_common_2.0.fxsub
+++ b/Materials/material_common_2.0.fxsub
@@ -1543,10 +1543,16 @@ GbufferParam MaterialPS(
 #if OCCLUSION_MAP_TYPE == 2 || OCCLUSION_MAP_TYPE == 3
 	in float2 coord1   : TEXCOORD2,
 #endif
+#ifndef MATERIAL_SINGLESIDE
+	in float  faceside : VFACE,
+#endif
 	in float4 worldPos : TEXCOORD3)
 {
 	normal = normalize(normal);
 
+#ifdef MATERIAL_SINGLESIDE
+	float faceside = 1;
+#endif
 #if PARALLAX_MAP_FROM
 	#if PARALLAX_MAP_UV_FLIP
 		coord0.y = 1 - coord0.y;
@@ -1566,7 +1572,7 @@ GbufferParam MaterialPS(
 
 	MaterialParam material;
 	material.albedo = GetSubAlbedo(GetAlbedo(coord0), coord0);
-	material.normal = GetNormal(normal, worldPos.xyz, coord0);
+	material.normal = GetNormal(normal, worldPos.xyz, coord0) * faceside;
 #if SPECULAR_ANTIALIASING_ENABLE
 	material.smoothness = GeometricNormalFiltering(GetSmoothness(coord0), material.normal, specularAntiAliasingVariance, specularAntiAliasingThreshold);
 #else
@@ -1595,10 +1601,16 @@ GbufferParam Material2PS(
 #if OCCLUSION_MAP_TYPE == 2 || OCCLUSION_MAP_TYPE == 3
 	in float2 coord1   : TEXCOORD2,
 #endif
+#ifndef MATERIAL_SINGLESIDE
+	in float  faceside : VFACE,
+#endif
 	in float4 worldPos : TEXCOORD3)
 {
 	normal = normalize(normal);
 
+#ifdef MATERIAL_SINGLESIDE
+	float faceside = 1;
+#endif
 #if PARALLAX_MAP_FROM
 	#if PARALLAX_MAP_UV_FLIP
 		coord0.y = 1 - coord0.y;
@@ -1623,7 +1635,7 @@ GbufferParam Material2PS(
 
 	MaterialParam material;
 	material.albedo = GetSubAlbedo(GetAlbedo(coord0), coord0);
-	material.normal = GetNormal(normal, worldPos.xyz, coord0);
+	material.normal = GetNormal(normal, worldPos.xyz, coord0) * faceside;
 	material.smoothness = min(geometricSmoothness, GetSmoothness(coord0));
 	material.metalness = GetMetalness(coord0);
 	material.specular = GetSpecular(coord0);
@@ -1677,4 +1689,5 @@ OBJECT_TEC(MainTecBS0, "object_ss")
 
 technique EdgeTec<string MMDPass = "edge";>{}
 technique ShadowTech<string MMDPass = "shadow";>{}
+
 technique ZplotTec<string MMDPass = "zplot";>{}

--- a/Materials/material_common_2.0.fxsub
+++ b/Materials/material_common_2.0.fxsub
@@ -1689,5 +1689,4 @@ OBJECT_TEC(MainTecBS0, "object_ss")
 
 technique EdgeTec<string MMDPass = "edge";>{}
 technique ShadowTech<string MMDPass = "shadow";>{}
-
 technique ZplotTec<string MMDPass = "zplot";>{}


### PR DESCRIPTION
Use VFACE pixel shader semantic to determine which side of a two-sided material is drawn, and adjust normal vector. This allows e.g. lighting to apply to both sides.

Define MATERIAL_SINGLESIDE in a material file to disable this.